### PR TITLE
Enable Generic Load Test for Gossipsub queues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ WORKDIR /app
 COPY requirements.txt .
 RUN pip install --no-cache-dir --break-system-packages -r requirements.txt
 COPY api_requester.py \
+    async_client.py \
     utils.py \
     configs.py \
     kube_client.py \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ client.py           Sample code to make API requests directed at a pod running t
 
 ### Changelog
 
+- `v3.0.0`:
+  - Added **load test mode** for high-throughput async testing
+  - New `LoadTestConfig` in actions with rate limiting and burst support
+  - Added `async_client.py` for aiohttp-based requests
+  - Added `/loadtest/*` API endpoints for server mode
 - `v2.0.0`:
   - Changed to using a ConfigMap to define Targets, Endpoints, Requests, and Actions
   - Added server capability
@@ -75,3 +80,52 @@ client.py           Sample code to make API requests directed at a pod running t
       (randomly choose a node using zerotesting-service)
 - `v1.0.0`:
   Initial version
+
+---
+
+### Load Test Mode
+
+Actions can run in **load test mode** for high-throughput async testing.
+
+#### Enabling Load Test Mode
+
+Add a `load_test` section to any action in `config.yaml`:
+
+```yaml
+actions:
+  - name: gossip-burst
+    requests: ["gossip-publish"]
+    targets: ["nim-nodes"]
+    order: ascending
+    loop_order: foreach_pod_make_all_requests
+    load_test:
+      enabled: true
+      rate_per_pod: 128.0       # messages/second per pod
+      messages_per_pod: 512     # total messages per pod
+```
+
+#### Load Test Configuration Options
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable load test mode |
+| `rate_per_pod` | float | - | Messages per second per pod |
+| `messages_per_pod` | int | - | Total messages per pod |
+| `duration_seconds` | float | - | Run duration (alternative to messages_per_pod) |
+| `burst_size` | int | - | Messages per burst |
+| `burst_delay` | float | - | Delay between bursts |
+| `parallel_workers` | bool | `true` | Run workers in parallel |
+| `request_timeout` | float | `30.0` | HTTP request timeout |
+
+#### HTTP API Endpoints (Server Mode)
+
+```bash
+# List actions with load_test enabled
+GET /loadtest/actions
+
+# Run a pre-configured load test action
+POST /loadtest/run/{action_name}
+
+# Run an inline load test
+POST /loadtest/inline
+```

--- a/api_requester.py
+++ b/api_requester.py
@@ -119,7 +119,6 @@ def do_action(
         logger.info(f"Running action '{action.name}' in load_test mode (pods={len(pods)})")
         return asyncio.run(run_load_test(action, pods))
 
-    # Synchronous mode
     if action.loop_order == "foreach_pod_make_all_requests":
         for pod in pods:
             for request in action.requests:

--- a/api_requester.py
+++ b/api_requester.py
@@ -1,4 +1,5 @@
 import argparse
+import asyncio
 import random
 from argparse import Namespace
 from collections import defaultdict
@@ -9,6 +10,7 @@ import uvicorn
 import yaml
 
 from app import create_app
+from async_client import run_load_test
 from common import call_endpoint, get_pod_infos
 from configs import ConfigAction, ConfigEndpoint, ConfigRequest, ConfigTarget
 from schemas import TargetPodInfo
@@ -112,6 +114,12 @@ def do_action(
         pods.append(possible_pods[index])
         index = (index + 1) % len(possible_pods)
 
+    # Load test mode (async)
+    if action.load_test.enabled:
+        logger.info(f"Running action '{action.name}' in load_test mode (pods={len(pods)})")
+        return asyncio.run(run_load_test(action, pods))
+
+    # Synchronous mode
     if action.loop_order == "foreach_pod_make_all_requests":
         for pod in pods:
             for request in action.requests:

--- a/api_requester.py
+++ b/api_requester.py
@@ -142,9 +142,14 @@ def main(args: Namespace):
         app = create_app(config)
         uvicorn.run(app, host="0.0.0.0", port=args.port, log_config=None)
     else:
-        pods_info = get_pod_infos(config["targets"])
-        for action in config["actions"]:
-            do_action(action, pods_info)
+        namespace = (
+            open("/var/run/secrets/kubernetes.io/serviceaccount/namespace").read().strip() or "default"
+        )
+        logger.info(f"Running in batch mode, namespace: {namespace}")
+        pods_info = get_pod_infos(list(config["targets"].values()), namespace)
+        for action in config["actions"].values():
+            result = do_action(action, pods_info)
+            logger.info(f"Action result: {result}")
 
 
 def mode_type(value):

--- a/async_client.py
+++ b/async_client.py
@@ -1,0 +1,304 @@
+"""
+Async HTTP client for load testing.
+
+Provides high-throughput message injection with rate limiting,
+burst mode, and parallel worker support.
+"""
+
+import asyncio
+import time
+import traceback
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from configs import ConfigAction, ConfigEndpoint, ConfigRequest, LoadTestConfig
+from schemas import TargetPodInfo
+from utils import setup_logger
+
+logger = setup_logger(__file__)
+
+
+@dataclass
+class RequestStats:
+    """Thread-safe statistics tracking for load test requests."""
+
+    success: int = 0
+    failure: int = 0
+    total: int = 0
+    total_latency_ms: float = 0.0
+    min_latency_ms: float = float("inf")
+    max_latency_ms: float = 0.0
+    _lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+
+    async def record(self, ok: bool, latency_ms: float) -> None:
+        async with self._lock:
+            self.total += 1
+            self.total_latency_ms += latency_ms
+            if latency_ms < self.min_latency_ms:
+                self.min_latency_ms = latency_ms
+            if latency_ms > self.max_latency_ms:
+                self.max_latency_ms = latency_ms
+            if ok:
+                self.success += 1
+            else:
+                self.failure += 1
+
+    async def snapshot(self) -> Dict[str, Any]:
+        async with self._lock:
+            success_rate = (self.success / self.total * 100.0) if self.total else 0.0
+            avg_latency = (self.total_latency_ms / self.total) if self.total else 0.0
+            return {
+                "success": self.success,
+                "failure": self.failure,
+                "total": self.total,
+                "success_rate": success_rate,
+                "avg_latency_ms": avg_latency,
+                "min_latency_ms": self.min_latency_ms if self.total else 0.0,
+                "max_latency_ms": self.max_latency_ms,
+            }
+
+
+@dataclass
+class WorkerContext:
+    """Context for a per-pod worker."""
+    worker_id: int
+    pod_info: TargetPodInfo
+    action: ConfigAction
+    session: aiohttp.ClientSession
+    stats: RequestStats
+
+
+def build_request_url(endpoint: ConfigEndpoint, pod_info: TargetPodInfo) -> str:
+    """Build the full URL for a request to a specific pod."""
+    return endpoint.url.format(
+        node=pod_info.pod.status.pod_ip,
+        port=pod_info.config_target.port,
+    )
+
+
+async def send_async_request(
+    ctx: WorkerContext,
+    request: ConfigRequest,
+    message_index: int,
+) -> Dict[str, Any]:
+    """Send a single async HTTP request and record stats."""
+    endpoint = request.endpoint
+    url = build_request_url(endpoint, ctx.pod_info)
+    pod_name = ctx.pod_info.pod_name
+    load_test = ctx.action.load_test
+
+    result_data: Dict[str, Any] = {
+        "request": {
+            "url": url,
+            "pod": pod_name,
+            "worker_id": ctx.worker_id,
+            "message_index": message_index,
+        }
+    }
+
+    start_time = time.time()
+
+    try:
+        response_data = await _do_http_request(
+            ctx.session, endpoint, url, load_test.request_timeout
+        )
+
+        elapsed_ms = (time.time() - start_time) * 1000.0
+        ok = response_data["status_code"] == 200
+
+        await ctx.stats.record(ok, elapsed_ms)
+        snap = await ctx.stats.snapshot()
+
+        result_data["response"] = response_data
+        result_data["elapsed_ms"] = elapsed_ms
+        result_data["stats"] = snap
+
+        logger.info(
+            "worker=%d message=%d pod=%s status=%d elapsed_ms=%.2f "
+            "success=%d failure=%d total=%d success_rate=%.2f%%",
+            ctx.worker_id,
+            message_index,
+            pod_name,
+            response_data["status_code"],
+            elapsed_ms,
+            snap["success"],
+            snap["failure"],
+            snap["total"],
+            snap["success_rate"],
+        )
+
+    except Exception as e:
+        elapsed_ms = (time.time() - start_time) * 1000.0
+        await ctx.stats.record(False, elapsed_ms)
+        snap = await ctx.stats.snapshot()
+
+        error_msg = traceback.format_exc()
+        result_data["exception"] = str(e)
+        result_data["traceback"] = error_msg
+        result_data["elapsed_ms"] = elapsed_ms
+        result_data["stats"] = snap
+
+        logger.warning(
+            "worker=%d message=%d pod=%s exception=%s elapsed_ms=%.2f "
+            "success=%d failure=%d total=%d success_rate=%.2f%%",
+            ctx.worker_id,
+            message_index,
+            pod_name,
+            repr(e),
+            elapsed_ms,
+            snap["success"],
+            snap["failure"],
+            snap["total"],
+            snap["success_rate"],
+        )
+
+    return result_data
+
+
+async def _do_http_request(
+    session: aiohttp.ClientSession,
+    endpoint: ConfigEndpoint,
+    url: str,
+    timeout: float,
+) -> Dict[str, Any]:
+    """Perform the actual HTTP request."""
+    timeout_obj = aiohttp.ClientTimeout(total=timeout)
+
+    if endpoint.type == "POST":
+        async with session.post(
+            url,
+            json=endpoint.params,
+            headers=endpoint.headers,
+            timeout=timeout_obj,
+        ) as response:
+            text = await response.text()
+            return {"status_code": response.status, "text": text[:500]}
+    elif endpoint.type == "GET":
+        async with session.get(
+            url,
+            params=endpoint.params,
+            headers=endpoint.headers,
+            timeout=timeout_obj,
+        ) as response:
+            text = await response.text()
+            return {"status_code": response.status, "text": text[:500]}
+    else:
+        raise ValueError(f"Unsupported request type: {endpoint.type}")
+
+
+async def run_pod_worker(ctx: WorkerContext) -> Dict[str, Any]:
+    """Worker that sends messages to a single pod at specified rate."""
+    load_test = ctx.action.load_test
+    requests_list = ctx.action.requests
+    pod_name = ctx.pod_info.pod_name
+
+    delay_seconds = load_test.get_delay_seconds()
+    burst_size = load_test.burst_size or 1
+    burst_delay = load_test.burst_delay or delay_seconds
+
+    start_time = time.time()
+    message_index = 0
+
+    logger.info(
+        "worker=%d pod=%s starting messages=%s duration=%s rate=%s",
+        ctx.worker_id, pod_name, load_test.messages_per_pod,
+        load_test.duration_seconds, load_test.rate_per_pod,
+    )
+
+    while True:
+        if load_test.messages_per_pod is not None and message_index >= load_test.messages_per_pod:
+            break
+        if load_test.duration_seconds is not None and (time.time() - start_time) >= load_test.duration_seconds:
+            break
+
+        # Send burst
+        burst_tasks = []
+        for _ in range(burst_size):
+            if load_test.messages_per_pod is not None and message_index >= load_test.messages_per_pod:
+                break
+            request = requests_list[message_index % len(requests_list)]
+            burst_tasks.append(asyncio.create_task(send_async_request(ctx, request, message_index)))
+            message_index += 1
+
+        if burst_tasks:
+            await asyncio.gather(*burst_tasks, return_exceptions=True)
+
+        await asyncio.sleep(burst_delay if burst_size > 1 else delay_seconds)
+
+    elapsed_total = time.time() - start_time
+    logger.info(
+        "worker=%d pod=%s finished messages=%d elapsed=%.2f",
+        ctx.worker_id, pod_name, message_index, elapsed_total,
+    )
+
+    return {
+        "worker_id": ctx.worker_id,
+        "pod": pod_name,
+        "messages_sent": message_index,
+        "elapsed_seconds": elapsed_total,
+    }
+
+
+async def run_load_test(
+    action: ConfigAction,
+    pods: List[TargetPodInfo],
+) -> Dict[str, Any]:
+    """Execute a load test action against multiple pods."""
+    load_test = action.load_test
+    load_test.validate_config()
+
+    if not pods:
+        raise ValueError("No target pods for load test")
+
+    stats = RequestStats()
+
+    start_time = time.time()
+    connector = aiohttp.TCPConnector(ttl_dns_cache=300, limit=0)
+    timeout = aiohttp.ClientTimeout(total=load_test.request_timeout)
+
+    async with aiohttp.ClientSession(timeout=timeout, connector=connector) as session:
+        if load_test.parallel_workers:
+            workers = []
+            for i, pod_info in enumerate(pods):
+                ctx = WorkerContext(
+                    worker_id=i,
+                    pod_info=pod_info,
+                    action=action,
+                    session=session,
+                    stats=stats,
+                )
+                workers.append(asyncio.create_task(run_pod_worker(ctx)))
+            worker_results = await asyncio.gather(*workers, return_exceptions=True)
+        else:
+            worker_results = []
+            for i, pod_info in enumerate(pods):
+                ctx = WorkerContext(
+                    worker_id=i,
+                    pod_info=pod_info,
+                    action=action,
+                    session=session,
+                    stats=stats,
+                )
+                result = await run_pod_worker(ctx)
+                worker_results.append(result)
+
+    elapsed_total = time.time() - start_time
+    final_stats = await stats.snapshot()
+
+    summary = {
+        "action": action.name,
+        "pods_count": len(pods),
+        "elapsed_seconds": elapsed_total,
+        "stats": final_stats,
+        "throughput_msg_per_sec": final_stats["total"] / elapsed_total if elapsed_total > 0 else 0,
+    }
+
+    logger.info(
+        "load_test_complete action=%s pods=%d total=%d success_rate=%.2f%% throughput=%.2f msg/s",
+        action.name, len(pods), final_stats["total"],
+        final_stats["success_rate"], summary["throughput_msg_per_sec"],
+    )
+
+    return summary

--- a/async_client.py
+++ b/async_client.py
@@ -253,6 +253,8 @@ async def run_load_test(
         raise ValueError("No target pods for load test")
 
     stats = RequestStats()
+    worker_results = []
+    worker_errors = []
 
     start_time = time.time()
     connector = aiohttp.TCPConnector(ttl_dns_cache=300, limit=0)
@@ -269,10 +271,16 @@ async def run_load_test(
                     session=session,
                     stats=stats,
                 )
-                workers.append(asyncio.create_task(run_pod_worker(ctx)))
-            worker_results = await asyncio.gather(*workers, return_exceptions=True)
+                workers.append((i, asyncio.create_task(run_pod_worker(ctx))))
+
+            for worker_id, task in workers:
+                try:
+                    result = await task
+                    worker_results.append(result)
+                except Exception as e:
+                    worker_errors.append({"worker_id": worker_id, "error": str(e)})
+                    logger.error(f"Worker {worker_id} failed: {e}")
         else:
-            worker_results = []
             for i, pod_info in enumerate(pods):
                 ctx = WorkerContext(
                     worker_id=i,
@@ -281,8 +289,12 @@ async def run_load_test(
                     session=session,
                     stats=stats,
                 )
-                result = await run_pod_worker(ctx)
-                worker_results.append(result)
+                try:
+                    result = await run_pod_worker(ctx)
+                    worker_results.append(result)
+                except Exception as e:
+                    worker_errors.append({"worker_id": i, "error": str(e)})
+                    logger.error(f"Worker {i} failed: {e}")
 
     elapsed_total = time.time() - start_time
     final_stats = await stats.snapshot()
@@ -293,6 +305,7 @@ async def run_load_test(
         "elapsed_seconds": elapsed_total,
         "stats": final_stats,
         "throughput_msg_per_sec": final_stats["total"] / elapsed_total if elapsed_total > 0 else 0,
+        "worker_errors": worker_errors,
     }
 
     logger.info(

--- a/async_client.py
+++ b/async_client.py
@@ -226,8 +226,11 @@ async def run_pod_worker(ctx: WorkerContext) -> Dict[str, Any]:
         await asyncio.sleep(burst_delay if burst_size > 1 else delay_seconds)
 
     # Wait for all in-flight requests to complete
-    if tasks:
-        await asyncio.gather(*tasks, return_exceptions=True)
+    for task in tasks:
+        try:
+            await task
+        except Exception as e:
+            logger.error(f"Request failed: {e}")
 
     elapsed_total = time.time() - start_time
     logger.info(

--- a/async_client.py
+++ b/async_client.py
@@ -207,6 +207,8 @@ async def run_pod_worker(ctx: WorkerContext) -> Dict[str, Any]:
         load_test.duration_seconds, load_test.rate_per_pod,
     )
 
+    tasks = []
+
     while True:
         if load_test.messages_per_pod is not None and message_index >= load_test.messages_per_pod:
             break
@@ -214,18 +216,18 @@ async def run_pod_worker(ctx: WorkerContext) -> Dict[str, Any]:
             break
 
         # Send burst
-        burst_tasks = []
         for _ in range(burst_size):
             if load_test.messages_per_pod is not None and message_index >= load_test.messages_per_pod:
                 break
             request = requests_list[message_index % len(requests_list)]
-            burst_tasks.append(asyncio.create_task(send_async_request(ctx, request, message_index)))
+            tasks.append(asyncio.create_task(send_async_request(ctx, request, message_index)))
             message_index += 1
 
-        if burst_tasks:
-            await asyncio.gather(*burst_tasks, return_exceptions=True)
-
         await asyncio.sleep(burst_delay if burst_size > 1 else delay_seconds)
+
+    # Wait for all in-flight requests to complete
+    if tasks:
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     elapsed_total = time.time() - start_time
     logger.info(

--- a/config.yaml
+++ b/config.yaml
@@ -94,4 +94,5 @@ data:
         load_test:
           enabled: true
           rate_per_pod: 2
+          parallel_workers: true
           messages_per_pod: 1200

--- a/config.yaml
+++ b/config.yaml
@@ -21,6 +21,17 @@ data:
         stateful_set: "client-0"
         port: 8645
 
+      # Example target for gossip priority queue testing
+      - name: nimp2pNodes
+        service: nimp2p-service
+        stateful_set: "nimp2p"
+        port: 8645
+
+      - name: nimp2pSlowNodes
+        service: nimp2p-service
+        stateful_set: "nimp2p-slow"
+        port: 8645
+
 
     endpoints:
       - name: set-debug
@@ -44,12 +55,25 @@ data:
         type: "POST"
         paged: False
 
+      # Gossip publish endpoint for nim-libp2p testing
+      - name: gossip-publish
+        url: "http://{node}:{port}/publish"
+        headers: {"Content-Type": "application/json"}
+        params: {"topic": "test", "msgSize": 1024, "version": 1}
+        type: "POST"
+        paged: False
+
 
     requests:
       - name: publish-request
         endpoint: lightpush-publish-static-sharding
         retries: 0
         retry_delay: 0.3
+
+      - name: gossip-medium
+        endpoint: gossip-publish
+        retries: 0
+        retry_delay: 0
 
     actions:
       - name: publish-to-clients-random
@@ -60,3 +84,14 @@ data:
         order: ascending
         loop_order: foreach_request_target_each_pod
 
+      # Load test: priority-queues test 2 msg/s per node, 1200 messages per node (10 minutes test duration)
+      - name: gossip-medium-overflow
+        requests: ["gossip-medium"]
+        targets: ["nimp2pNodes"]
+        pod_count: "all"
+        order: ascending
+        loop_order: foreach_pod_make_all_requests
+        load_test:
+          enabled: true
+          rate_per_pod: 2
+          messages_per_pod: 1200

--- a/configs.py
+++ b/configs.py
@@ -1,10 +1,10 @@
 import datetime
 import logging
 import re
-from typing import List, Literal, Optional
+from typing import List, Literal, Optional, Union
 
 from kubernetes.client.models.v1_pod import V1Pod
-from pydantic import BaseModel, NonNegativeFloat, NonNegativeInt, PositiveInt
+from pydantic import BaseModel, NonNegativeFloat, NonNegativeInt, PositiveFloat, PositiveInt
 
 from kube_client import core_v1
 
@@ -145,6 +145,30 @@ class ConfigTarget(BaseModel):
         return True
 
 
+class LoadTestConfig(BaseModel):
+    """Load testing mode configuration."""
+
+    enabled: bool = False
+    rate_per_pod: Optional[PositiveFloat] = None
+    messages_per_pod: Optional[PositiveInt] = None
+    duration_seconds: Optional[PositiveFloat] = None
+    parallel_workers: bool = True
+    request_timeout: PositiveFloat = 30.0
+    burst_size: Optional[PositiveInt] = None
+    burst_delay: Optional[PositiveFloat] = None
+
+    def get_delay_seconds(self) -> float:
+        if self.rate_per_pod is not None:
+            return 1.0 / self.rate_per_pod
+        return 1.0
+
+    def validate_config(self) -> None:
+        if not self.enabled:
+            return
+        if self.messages_per_pod is None and self.duration_seconds is None:
+            raise ValueError("Load test requires 'messages_per_pod' or 'duration_seconds'")
+
+
 class ConfigAction(BaseModel):
     """Description of an action to take. Here is how an action is performed:
     1. For each ConfigTarget, add all pods to the list.
@@ -217,3 +241,5 @@ class ConfigAction(BaseModel):
     requests: List[ConfigRequest]
     """The list of requests to do for each pod that ends up in the list of pods to request to.
     Every request will be executed, but it may not be on all pods matching every `ConfigTarget` in `targets`. See `targets`."""
+
+    load_test: LoadTestConfig = LoadTestConfig()

--- a/routers/generic.py
+++ b/routers/generic.py
@@ -86,7 +86,9 @@ def create_router(get_config: Callable[[], Awaitable[dict]]) -> APIRouter:
         action_name: str,
         config=Depends(get_config),
     ):
-        """Run a pre-configured load test action."""
+        """Run a load test action defined in config.yaml. 
+        Targets the first pod in the list to act as the message injector.
+        """
         if action_name not in config["actions"]:
             raise NotFoundError(f"Action not found: {action_name}")
 
@@ -95,17 +97,18 @@ def create_router(get_config: Callable[[], Awaitable[dict]]) -> APIRouter:
         if not action.load_test.enabled:
             return {"error": "load_test not enabled for this action"}
 
-        pods = get_pod_infos(
-            targets=action.targets,
-            namespace=request.app.state.namespace,
-            cache=request.app.state.cache,
-        )
+        try:
+            pods = get_pod_infos(
+                targets=action.targets,
+                namespace=request.app.state.namespace,
+                cache=request.app.state.cache,
+            )
+            pod_info = next(iter(pods))
+        except StopIteration as e:
+            raise NotFoundError(f"No pods found for action: {action_name}") from e
 
-        if not pods:
-            raise NotFoundError(f"No pods found for action: {action_name}")
-
-        logger.info(f"load_test action={action_name} pods={len(pods)}")
-        return await run_load_test(action, pods)
+        logger.info(f"load_test action={action_name} pod={pod_info.pod_name}")
+        return await run_load_test(action, [pod_info])
 
     @router.post("/loadtest/inline")
     @endpoint_error_handler
@@ -114,7 +117,9 @@ def create_router(get_config: Callable[[], Awaitable[dict]]) -> APIRouter:
         data: LoadTestInlineRequest,
         config=Depends(get_config),
     ):
-        """Run an inline load test."""
+        """Run an ad-hoc load test with parameters from the request body.
+        Targets the first pod in the list to act as the message injector.
+        """
         target = unwrap_arg(data.target, "targets", config)
 
         if data.endpoint not in config["endpoints"]:
@@ -132,7 +137,7 @@ def create_router(get_config: Callable[[], Awaitable[dict]]) -> APIRouter:
         )
         load_test_config.validate_config()
 
-        temp_action = ConfigAction(
+        inline_action = ConfigAction(
             name="inline_load_test",
             loop_order="foreach_pod_make_all_requests",
             targets=[target],
@@ -141,16 +146,17 @@ def create_router(get_config: Callable[[], Awaitable[dict]]) -> APIRouter:
             load_test=load_test_config,
         )
 
-        pods = get_pod_infos(
-            targets=[target],
-            namespace=request.app.state.namespace,
-            cache=request.app.state.cache,
-        )
+        try:
+            pods = get_pod_infos(
+                targets=[target],
+                namespace=request.app.state.namespace,
+                cache=request.app.state.cache,
+            )
+            pod_info = next(iter(pods))
+        except StopIteration as e:
+            raise NotFoundError(f"No pods found for target: {target.name}") from e
 
-        if not pods:
-            raise NotFoundError(f"No pods found for target: {target.name}")
-
-        logger.info(f"inline load_test pods={len(pods)} endpoint={data.endpoint}")
-        return await run_load_test(temp_action, pods)
+        logger.info(f"inline load_test pod={pod_info.pod_name} endpoint={data.endpoint}")
+        return await run_load_test(inline_action, [pod_info])
 
     return router

--- a/routers/generic.py
+++ b/routers/generic.py
@@ -1,14 +1,28 @@
-from typing import Awaitable, Callable
+from typing import Annotated, Awaitable, Callable, Optional, Union
 
 from fastapi import APIRouter, Depends, Request
+from pydantic import BaseModel, Field, PositiveFloat, PositiveInt
 
+from async_client import run_load_test
 from common import call_endpoint, get_pod_infos
-from configs import ConfigRequest
-from routers.deps import InvokeRequestData, endpoint_error_handler, unwrap_arg
+from configs import ConfigAction, ConfigRequest, LoadTestConfig
+from routers.deps import InvokeRequestData, TargetConfig, TargetName, endpoint_error_handler, unwrap_arg
 from schemas import NotFoundError
 from utils import setup_logger
 
 logger = setup_logger(__file__)
+
+
+class LoadTestInlineRequest(BaseModel):
+    """Inline load test request."""
+    target: Annotated[Union[TargetName, TargetConfig], Field(discriminator="kind")]
+    endpoint: str
+
+    rate_per_pod: Optional[PositiveFloat] = None
+    messages_per_pod: Optional[PositiveInt] = None
+    duration_seconds: Optional[PositiveFloat] = None
+    burst_size: Optional[PositiveInt] = None
+    burst_delay: Optional[PositiveFloat] = None
 
 
 def create_router(get_config: Callable[[], Awaitable[dict]]) -> APIRouter:
@@ -52,5 +66,91 @@ def create_router(get_config: Callable[[], Awaitable[dict]]) -> APIRouter:
     ):
         request.app.state.cache.clear()
         return {"cleared": True}
+
+    @router.get("/loadtest/actions")
+    @endpoint_error_handler
+    async def list_loadtest_actions(config=Depends(get_config)):
+        """List actions with load_test enabled."""
+        return {
+            "actions": list(config["actions"].keys()),
+            "load_test_actions": [
+                name for name, action in config["actions"].items()
+                if action.load_test.enabled
+            ],
+        }
+
+    @router.post("/loadtest/run/{action_name}")
+    @endpoint_error_handler
+    async def run_loadtest_action(
+        request: Request,
+        action_name: str,
+        config=Depends(get_config),
+    ):
+        """Run a pre-configured load test action."""
+        if action_name not in config["actions"]:
+            raise NotFoundError(f"Action not found: {action_name}")
+
+        action: ConfigAction = config["actions"][action_name]
+
+        if not action.load_test.enabled:
+            return {"error": "load_test not enabled for this action"}
+
+        pods = get_pod_infos(
+            targets=action.targets,
+            namespace=request.app.state.namespace,
+            cache=request.app.state.cache,
+        )
+
+        if not pods:
+            raise NotFoundError(f"No pods found for action: {action_name}")
+
+        logger.info(f"load_test action={action_name} pods={len(pods)}")
+        return await run_load_test(action, pods)
+
+    @router.post("/loadtest/inline")
+    @endpoint_error_handler
+    async def run_inline_loadtest(
+        request: Request,
+        data: LoadTestInlineRequest,
+        config=Depends(get_config),
+    ):
+        """Run an inline load test."""
+        target = unwrap_arg(data.target, "targets", config)
+
+        if data.endpoint not in config["endpoints"]:
+            raise NotFoundError(f"Endpoint not found: {data.endpoint}")
+
+        endpoint = config["endpoints"][data.endpoint]
+
+        load_test_config = LoadTestConfig(
+            enabled=True,
+            rate_per_pod=data.rate_per_pod,
+            messages_per_pod=data.messages_per_pod,
+            duration_seconds=data.duration_seconds,
+            burst_size=data.burst_size,
+            burst_delay=data.burst_delay,
+        )
+        load_test_config.validate_config()
+
+        temp_action = ConfigAction(
+            name="inline_load_test",
+            loop_order="foreach_pod_make_all_requests",
+            targets=[target],
+            requests=[ConfigRequest(name="inline", endpoint=endpoint, retries=0, retry_delay=0)],
+            order="ascending",
+            load_test=load_test_config,
+        )
+
+        pods = get_pod_infos(
+            targets=[target],
+            namespace=request.app.state.namespace,
+            cache=request.app.state.cache,
+        )
+
+        if not pods:
+            raise NotFoundError(f"No pods found for target: {target.name}")
+
+        logger.info(f"inline load_test pods={len(pods)} endpoint={data.endpoint}")
+        return await run_load_test(temp_action, pods)
 
     return router


### PR DESCRIPTION
- Add LoadTestConfig
  - include rate_per_pod, messages_per_pod, async parallel worker mode, burst_size, burst_delay (required for benchmarking priority queues and causing queues overflow)
- Update config.yaml with new example to showcase medium queue overflow
- Update Dockerfile