### PR TITLE
Shadow Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Python
+__pycache__/
+*.py[cod]
+*.egg-info/
+
+# Virtual environments
+.venv/
+venv/

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY api_requester.py \
     configs.py \
     kube_client.py \
     common.py \
+    shadow_resolver.py \
     schemas.py \
     app.py \
     /app/

--- a/README.md
+++ b/README.md
@@ -48,13 +48,9 @@ Actions - Combines Targets and Requests into a defined action, representing a se
 
 By default a Target is resolved through the Kubernetes API (by `service`,
 `name_template`, and/or `stateful_set`). A Target can instead be resolved purely
-by hostname, with no Kubernetes API calls, useful for the Shadow simulator or
-any environment without a control plane. Set one of:
-
-- `hosts`: an explicit list of hostnames, e.g. `["pod-0", "pod-1"]`.
-- `host_template` + `host_count`: `host_template` is expanded over
-  `range(host_count)`, e.g. `host_template: "pod-{i}"` with `host_count: 100`
-  yields `pod-0` .. `pod-99`.
+by hostname via `hosts` — an explicit list, e.g. `["pod-0", "pod-1"]` — with no
+Kubernetes API calls, useful for the Shadow simulator or any environment without
+a control plane.
 
 The hostname is substituted into the endpoint URL's `{node}` and resolved by the
 HTTP client's OS resolver at request time. Static and Kubernetes targets can be
@@ -87,7 +83,7 @@ client.py           Sample code to make API requests directed at a pod running t
 ### Changelog
 
 - `v3.1.0`:
-  - Added static / DNS-based target resolution (`hosts`, or `host_template` + `host_count`),
+  - Added static / DNS-based target resolution (`hosts`: an explicit hostname list),
     so targets can be addressed by hostname with no Kubernetes API calls (e.g. inside the
     Shadow simulator).
   - `--mode batch` no longer requires a Kubernetes connection when all targets are static:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ The script is designed to run inside a Docker container.
 The script can be run in one of two modes: `server` or `batch`.
 
 #### Batch Mode
-Simply runs all actions sequentially
+
+`python ./api_requester.py --mode batch --config /mount/config.yaml`
+
+Runs all actions in the config sequentially, then exits. 
+
+Add `--namespace <ns>` when any target is resolved through the Kubernetes API.
+It can be omitted when every target is static, which is how the requester runs 
+in environments without a Kubernetes control plane such as the Shadow network simulator.
+
+See `examples/shadow_publish.yaml` for a complete batch config.
 
 #### Server Mode
 
@@ -30,10 +39,26 @@ they work together when running an action or making a request.
 Each config object has a name by which it can be referenced.
 Some fields are optional.
 
-Endpoints - Defines an API endpoint for a request.
-Targets - Defines a set of filters to use to determine if pods on a cluster are part of the target.
+Endpoints - Defines an API endpoint for a request. May set a `timeout` (seconds, default 30).
+Targets - Defines a set of filters to use to determine if pods on a cluster are part of the target. May instead be resolved by hostname — see "Static targets".
 Requests - Contains an Endpoint and some additional information for retries and delays.
-Actions - Combines Targets and Requests into a defined action, representing a series of requests.
+Actions - Combines Targets and Requests into a defined action, representing a series of requests. May set a `delay` (seconds) to pace requests.
+
+#### Static targets (no Kubernetes)
+
+By default a Target is resolved through the Kubernetes API (by `service`,
+`name_template`, and/or `stateful_set`). A Target can instead be resolved purely
+by hostname, with no Kubernetes API calls, useful for the Shadow simulator or
+any environment without a control plane. Set one of:
+
+- `hosts`: an explicit list of hostnames, e.g. `["pod-0", "pod-1"]`.
+- `host_template` + `host_count`: `host_template` is expanded over
+  `range(host_count)`, e.g. `host_template: "pod-{i}"` with `host_count: 100`
+  yields `pod-0` .. `pod-99`.
+
+The hostname is substituted into the endpoint URL's `{node}` and resolved by the
+HTTP client's OS resolver at request time. Static and Kubernetes targets can be
+mixed in the same config.
 
 #### How an Action is performed
 
@@ -61,6 +86,16 @@ client.py           Sample code to make API requests directed at a pod running t
 
 ### Changelog
 
+- `v2.1.0`:
+  - Added static / DNS-based target resolution (`hosts`, or `host_template` + `host_count`),
+    so targets can be addressed by hostname with no Kubernetes API calls (e.g. inside the
+    Shadow simulator).
+  - `--mode batch` no longer requires a Kubernetes connection when all targets are static:
+    the in-cluster client is created lazily, and `--namespace` is optional in that case.
+  - Added `delay` on Actions (pacing between requests) and `timeout` on Endpoints
+    (per-request HTTP timeout, default 30s — previously requests could block indefinitely).
+  - Fixed the batch-mode action path (target/action iteration, namespace passing) and made
+    pod ordering numeric (`pod-2` before `pod-10`).
 - `v2.0.0`:
   - Changed to using a ConfigMap to define Targets, Endpoints, Requests, and Actions
   - Added server capability

--- a/api_requester.py
+++ b/api_requester.py
@@ -8,8 +8,10 @@ from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List
 
+import uvicorn
 import yaml
 
+from app import create_app
 from async_client import run_load_test
 from common import call_endpoint, get_pod_infos
 from configs import ConfigAction, ConfigEndpoint, ConfigRequest, ConfigTarget
@@ -144,12 +146,6 @@ def main(args: Namespace):
     available_endpoints = [endpoint.name for endpoint in config["endpoints"].values()]
     logger.debug(f"Loaded config. Available endpoints: {available_endpoints}")
     if args.mode == "server":
-        # `uvicorn` and `app` (FastAPI) are imported lazily so that batch mode
-        # does not require the server-only dependencies (fastapi/uvicorn).
-        import uvicorn
-
-        from app import create_app
-
         app = create_app(config)
         uvicorn.run(app, host="0.0.0.0", port=args.port, log_config=None)
     else:

--- a/api_requester.py
+++ b/api_requester.py
@@ -1,14 +1,14 @@
 import argparse
 import random
+import re
+import time
 from argparse import Namespace
 from collections import defaultdict
 from pathlib import Path
 from typing import Dict, List
 
-import uvicorn
 import yaml
 
-from app import create_app
 from common import call_endpoint, get_pod_infos
 from configs import ConfigAction, ConfigEndpoint, ConfigRequest, ConfigTarget
 from schemas import TargetPodInfo
@@ -89,6 +89,10 @@ def load_configs(config_files: List[str]) -> Dict[str, Dict[str, object]]:
     return parse_config(full_config)
 
 
+def _natural_key(name: str):
+    return [int(part) if part.isdigit() else part for part in re.split(r"(\d+)", name)]
+
+
 def do_action(
     action: ConfigAction,
     pods: List[TargetPodInfo],
@@ -99,9 +103,9 @@ def do_action(
     if action.order == "random":
         random.shuffle(possible_pods)
     elif action.order == "ascending":
-        possible_pods.sort(key=lambda pod: pod.pod_name)
+        possible_pods.sort(key=lambda pod: _natural_key(pod.pod_name))
     elif action.order == "descending":
-        possible_pods.sort(key=lambda pod: pod.pod_name, reverse=True)
+        possible_pods.sort(key=lambda pod: _natural_key(pod.pod_name), reverse=True)
     else:
         raise ValueError(f"Unknown order for action: {action.order}")
 
@@ -115,13 +119,15 @@ def do_action(
     if action.loop_order == "foreach_pod_make_all_requests":
         for pod in pods:
             for request in action.requests:
-                # time.sleep(delay_between_requests) TODO
-                call_endpoint(request, pod)
+                call_endpoint(request.endpoint, pod)
+                if action.delay:
+                    time.sleep(action.delay)
     elif action.loop_order == "foreach_request_target_each_pod":
         for request in action.requests:
-            # TODO: ensure time between requests has elapsed
             for pod in pods:
-                call_endpoint(request, pod)
+                call_endpoint(request.endpoint, pod)
+                if action.delay:
+                    time.sleep(action.delay)
     else:
         raise ValueError(f"Unknown loop_order for action: {action}")
 
@@ -131,11 +137,18 @@ def main(args: Namespace):
     available_endpoints = [endpoint.name for endpoint in config["endpoints"].values()]
     logger.debug(f"Loaded config. Available endpoints: {available_endpoints}")
     if args.mode == "server":
+    # Note: `uvicorn` and `app` (FastAPI) are imported lazily here
+    # so that batch mode does not require the server-only dependencies.
+        import uvicorn
+
+        from app import create_app
+
         app = create_app(config)
         uvicorn.run(app, host="0.0.0.0", port=args.port, log_config=None)
     else:
-        pods_info = get_pod_infos(config["targets"])
-        for action in config["actions"]:
+        targets = list(config["targets"].values())
+        pods_info = get_pod_infos(targets, namespace=args.namespace)
+        for action in config["actions"].values():
             do_action(action, pods_info)
 
 
@@ -166,6 +179,13 @@ def parse_args() -> argparse.Namespace:
         type=int,
         default=8645,
         help="Port for the action HTTP server (default 8645)",
+    )
+    parser.add_argument(
+        "--namespace",
+        type=str,
+        default=None,
+        help="Kubernetes namespace for resolving k8s targets in batch mode. "
+        "Not required when all targets are static (e.g. Shadow).",
     )
 
     args = parser.parse_args()

--- a/common.py
+++ b/common.py
@@ -85,9 +85,10 @@ def get_pod_infos(
         if namespace is None:
             raise ValueError(f"namespace is required to resolve Kubernetes target `{target.name}`.")
         svc_key = target.service or CACHE_ALL_KEY
-        try:
-            pods = cache[namespace][svc_key]
-        except (TypeError, KeyError):
+        cached = cache.get(namespace) if cache is not None else None
+        if cached is not None and svc_key in cached:
+            pods = cached[svc_key]
+        else:
             pods = get_pods(service=target.service, namespace=namespace)
             if cache is not None:
                 cache[namespace][svc_key] = pods

--- a/common.py
+++ b/common.py
@@ -6,8 +6,9 @@ import requests
 from kubernetes.client.models.v1_pod import V1Pod
 
 from configs import ConfigEndpoint, ConfigRequest, ConfigTarget
-from kube_client import core_v1
+from kube_client import get_core_v1
 from schemas import TargetPodInfo
+from shadow_resolver import resolve_static_target
 from utils import paged_request, setup_logger
 
 logger = setup_logger(__file__)
@@ -25,9 +26,10 @@ def call_endpoint(endpoint: ConfigEndpoint, pod_info: TargetPodInfo) -> dict:
 
     try:
         request_data["url"] = endpoint.url.format(
-            node=pod_info.pod.status.pod_ip, port=pod_info.config_target.port
+            node=pod_info.node_address, port=pod_info.config_target.port
         )
-        request_data["pod"] = f"{pod_info.pod.metadata.name}"
+        request_data["pod"] = f"{pod_info.pod_name}"
+        request_data["timeout"] = endpoint.timeout
         logger.info(f"request_data: {request_data}")
 
         if endpoint.paged:
@@ -40,12 +42,14 @@ def call_endpoint(endpoint: ConfigEndpoint, pod_info: TargetPodInfo) -> dict:
                     request_data["url"],
                     json=request_data["params"],
                     headers=request_data["headers"],
+                    timeout=request_data["timeout"],
                 )
             elif endpoint.type == "GET":
                 result = requests.get(
                     request_data["url"],
                     json=request_data["params"],
                     headers=request_data["headers"],
+                    timeout=request_data["timeout"],
                 )
             else:
                 raise AttributeError(f"Unknown request type. request: `{endpoint}`")
@@ -68,12 +72,18 @@ def call_endpoint(endpoint: ConfigEndpoint, pod_info: TargetPodInfo) -> dict:
 
 def get_pod_infos(
     targets: List[ConfigTarget],
-    namespace: str,
+    namespace: Optional[str] = None,
     *,
     cache: Optional[defaultdict] = None,
 ) -> List[TargetPodInfo]:
     pods_info: List[TargetPodInfo] = []
     for target in targets:
+        if target.is_static:
+            # shadow path
+            pods_info.extend(resolve_static_target(target))
+            continue
+        if namespace is None:
+            raise ValueError(f"namespace is required to resolve Kubernetes target `{target.name}`.")
         svc_key = target.service or CACHE_ALL_KEY
         try:
             pods = cache[namespace][svc_key]
@@ -87,6 +97,7 @@ def get_pod_infos(
 
 
 def get_pods(*, namespace: str, service: Optional[str]) -> List[str]:
+    core_v1 = get_core_v1()
     if service:
         service = core_v1.read_namespaced_service(service, namespace)
         selector = service.spec.selector

--- a/configs.py
+++ b/configs.py
@@ -125,19 +125,12 @@ class ConfigTarget(BaseModel):
 
     hosts: Optional[List[str]] = None
     """Explicit list of hostnames to target, e.g. ["pod-0", "pod-1"].
-    Resolved directly by DNS, with no Kubernetes API calls."""
-
-    host_template: Optional[str] = None
-    """Hostname template expanded over range(host_count), e.g. "pod-{i}".
-    Use together with `host_count`. Resolved by DNS, no Kubernetes API."""
-
-    host_count: Optional[NonNegativeInt] = None
-    """Number of hosts to expand `host_template` over (i = 0 .. host_count-1)."""
+    Resolved directly by DNS, with no Kubernetes API calls (e.g. Shadow hosts)."""
 
     @property
     def is_static(self) -> bool:
-        """True if this target is resolved by hostname convention (no k8s API)."""
-        return self.hosts is not None or self.host_template is not None
+        """True if this target is resolved by hostname (no k8s API)."""
+        return self.hosts is not None
 
     def matches(self, pod: V1Pod, namespace: str) -> bool:
         """Check if pod is a valid target of self"""

--- a/configs.py
+++ b/configs.py
@@ -6,7 +6,7 @@ from typing import List, Literal, Optional
 from kubernetes.client.models.v1_pod import V1Pod
 from pydantic import BaseModel, NonNegativeFloat, NonNegativeInt, PositiveInt
 
-from kube_client import core_v1
+from kube_client import get_core_v1
 
 
 class UTCFormatter(logging.Formatter):
@@ -75,6 +75,11 @@ class ConfigEndpoint(BaseModel):
     paged: bool
     """Use `True` if the request returns paged data. Otherwise, use `False`."""
 
+    timeout: NonNegativeFloat = 30.0
+    """Per-request timeout in seconds, passed to the HTTP client. Bounds how long a
+    single request waits before giving up, so one unresponsive target can't stall a
+    whole batch run. Default is 30s."""
+
 
 class ConfigRequest(BaseModel):
     """A request to be made to a pod.
@@ -118,6 +123,22 @@ class ConfigTarget(BaseModel):
     """Port to use for requests to endpoints with this target.
     Default is 80."""
 
+    hosts: Optional[List[str]] = None
+    """Explicit list of hostnames to target, e.g. ["pod-0", "pod-1"].
+    Resolved directly by DNS, with no Kubernetes API calls."""
+
+    host_template: Optional[str] = None
+    """Hostname template expanded over range(host_count), e.g. "pod-{i}".
+    Use together with `host_count`. Resolved by DNS, no Kubernetes API."""
+
+    host_count: Optional[NonNegativeInt] = None
+    """Number of hosts to expand `host_template` over (i = 0 .. host_count-1)."""
+
+    @property
+    def is_static(self) -> bool:
+        """True if this target is resolved by hostname convention (no k8s API)."""
+        return self.hosts is not None or self.host_template is not None
+
     def matches(self, pod: V1Pod, namespace: str) -> bool:
         """Check if pod is a valid target of self"""
 
@@ -137,7 +158,7 @@ class ConfigTarget(BaseModel):
                 return False
 
         if self.service is not None:
-            service = core_v1.read_namespaced_service(self.service, namespace)
+            service = get_core_v1().read_namespaced_service(self.service, namespace)
             selector = service.spec.selector
             if not all([pod.metadata.labels.get(key) == value for key, value in selector.items()]):
                 return False
@@ -190,6 +211,11 @@ class ConfigAction(BaseModel):
     order: Literal["ascending", "descending", "random"] | None
     """Once the list of possible pods is gathered by combining the lists of pods for each `ConfigTarget`,
     they will be sorted by this ordering before applying `pod_start_index` and `pod_count`.
+    """
+
+    delay: NonNegativeFloat = 0
+    """Seconds to sleep after each individual request is sent, to pace traffic.
+    0 (default) preserves the original back-to-back behaviour. 
     """
 
     targets: List[ConfigTarget]

--- a/examples/shadow_publish.yaml
+++ b/examples/shadow_publish.yaml
@@ -1,0 +1,39 @@
+# Example batch config for the in-Shadow libp2p publisher.
+#
+# Run inside the Shadow simulator as the `publisher` host:
+#   python api_requester.py --mode batch --config examples/shadow_publish.yaml
+#
+# This reproduces the legacy traffic_sync.py injector: publish `pod_count`
+# messages, one to each of pod-0, pod-1, ... in turn (round-robin), spaced
+# `delay` seconds apart, to each peer's /publish REST endpoint. Targets are
+# resolved purely by hostname (Shadow DNS) -- no Kubernetes API is used.
+
+targets:
+  - name: peers
+    host_template: "pod-{i}"   # Shadow host names
+    host_count: 100            # = PEERS / num_nodes
+    port: 8645                 # nim test-node REST port
+
+endpoints:
+  - name: libp2p-publish
+    url: "http://{node}:{port}/publish"
+    headers: { "Content-Type": "application/json" }
+    params: { "topic": "test", "msgSize": 1000, "version": 1 }
+    type: "POST"
+    paged: false
+
+requests:
+  - name: publish
+    endpoint: libp2p-publish
+    retries: 0
+    retry_delay: 0
+
+actions:
+  - name: inject-traffic
+    requests: ["publish"]
+    targets: ["peers"]
+    order: ascending           # numeric: pod-0, pod-1, ... (natural sort)
+    pod_start_index: 0
+    pod_count: 5               # = num_messages
+    delay: 2.0                 # seconds between messages (= delay_seconds)
+    loop_order: foreach_request_target_each_pod

--- a/examples/shadow_publish.yaml
+++ b/examples/shadow_publish.yaml
@@ -10,8 +10,10 @@
 
 targets:
   - name: peers
-    host_template: "pod-{i}"   # Shadow host names
-    host_count: 100            # = PEERS / num_nodes
+    # Explicit Shadow hostnames. 10ksim generates the full pod-0..pod-(N-1)
+    # list from num_nodes; shown here for a 10-node run.
+    hosts: ["pod-0", "pod-1", "pod-2", "pod-3", "pod-4",
+            "pod-5", "pod-6", "pod-7", "pod-8", "pod-9"]
     port: 8645                 # nim test-node REST port
 
 endpoints:

--- a/kube_client.py
+++ b/kube_client.py
@@ -1,4 +1,21 @@
+from functools import cache
+
 from kubernetes import client, config
 
-config.load_incluster_config()
-core_v1 = client.CoreV1Api()
+
+@cache
+def get_core_v1():
+    """Create a CoreV1Api client, memoized after the first call.
+
+    Importing this module must not connect to Kubernetes. Connecting at import
+    time breaks every non-cluster use of the requester. Client creation is deferred
+    until a Kubernetes target is actually resolved.
+
+    Prefers in-cluster config (running as a pod), falling back to a local
+    kubeconfig so the requester can also be run against a cluster from outside.
+    """
+    try:
+        config.load_incluster_config()
+    except config.ConfigException:
+        config.load_kube_config()
+    return client.CoreV1Api()

--- a/schemas.py
+++ b/schemas.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from kubernetes.client.models.v1_pod import V1Pod
 from pydantic import BaseModel, ConfigDict
 
@@ -8,11 +10,33 @@ class TargetPodInfo(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     config_target: ConfigTarget
-    pod: V1Pod
+
+    pod: Optional[V1Pod] = None
+    """The Kubernetes pod object. Set for k8s-resolved targets."""
+
+    host: Optional[str] = None
+    """Hostname for statically/DNS-resolved targets (e.g. the Shadow host
+    "pod-3"). Set instead of `pod` when the target did not come from the
+    Kubernetes API. See shadow_resolver.py."""
 
     @property
     def pod_name(self) -> str:
-        return self.pod.metadata.name
+        if self.pod is not None:
+            return self.pod.metadata.name
+        if self.host is not None:
+            return self.host
+        raise ValueError("TargetPodInfo has neither `pod` nor `host` set.")
+
+    @property
+    def node_address(self) -> str:
+        """Address substituted into an endpoint URL's `{node}`: the pod IP for
+        k8s targets, or the hostname (resolved by the HTTP client's OS resolver)
+        for static targets."""
+        if self.pod is not None:
+            return self.pod.status.pod_ip
+        if self.host is not None:
+            return self.host
+        raise ValueError("TargetPodInfo has neither `pod` nor `host` set.")
 
 
 class NotFoundError(LookupError):

--- a/shadow_resolver.py
+++ b/shadow_resolver.py
@@ -4,8 +4,8 @@ In environments without a Kubernetes control plane -- notably the Shadow
 network simulator -- peers are not k8s pods: they are simulated hosts named by
 convention (``pod-0`` .. ``pod-(N-1)``) and reachable only through the
 simulator's internal DNS. This module resolves "static" ``ConfigTarget``s to
-``TargetPodInfo`` objects purely by expanding a hostname pattern, with no calls
-to the Kubernetes API.
+``TargetPodInfo`` objects from their explicit ``hosts`` list, with no calls to
+the Kubernetes API.
 
 Keeping this in its own module is deliberate: the non-k8s resolution path never
 imports ``kube_client`` / the API client, so it works in a bare Python process
@@ -23,37 +23,17 @@ from utils import setup_logger
 logger = setup_logger(__file__)
 
 
-def expand_hosts(target: ConfigTarget) -> List[str]:
-    """Expand a static target into the concrete list of hostnames it addresses.
-
-    Two forms are supported:
-      * ``hosts``: an explicit list of hostnames.
-      * ``host_template`` + ``host_count``: ``host_template`` is formatted with
-        ``i`` over ``range(host_count)`` -- e.g. ``"pod-{i}"`` with
-        ``host_count=100`` yields ``pod-0`` .. ``pod-99``.
-    """
-    if target.hosts is not None:
-        return list(target.hosts)
-    if target.host_template is not None:
-        if target.host_count is None:
-            raise ValueError(
-                f"Static target `{target.name}` sets `host_template` but not `host_count`."
-            )
-        return [target.host_template.format(i=i) for i in range(target.host_count)]
-    raise ValueError(
-        f"Static target `{target.name}` must set either `hosts` or "
-        f"`host_template` (+ `host_count`)."
-    )
-
-
 def resolve_static_target(target: ConfigTarget) -> List[TargetPodInfo]:
     """Resolve a static (non-k8s) target to ``TargetPodInfo`` objects by hostname.
 
-    The hostname is stored in ``TargetPodInfo.host``; it is substituted into the
-    endpoint URL's ``{node}`` and resolved by the HTTP client's OS resolver
-    (e.g. Shadow's internal DNS) at request time -- no IP lookup happens here.
+    Each hostname in ``target.hosts`` is stored in ``TargetPodInfo.host``; it is
+    substituted into the endpoint URL's ``{node}`` and resolved by the HTTP
+    client's OS resolver (e.g. Shadow's internal DNS) at request time -- no IP
+    lookup happens here.
     """
-    hosts = expand_hosts(target)
+    if not target.hosts:
+        raise ValueError(f"Static target `{target.name}` must set `hosts`.")
+    hosts = list(target.hosts)
     preview = hosts[:5]
     logger.info(
         f"Resolved static target `{target.name}` to {len(hosts)} host(s): "

--- a/shadow_resolver.py
+++ b/shadow_resolver.py
@@ -1,0 +1,62 @@
+"""Static / DNS-based target resolution (no Kubernetes).
+
+In environments without a Kubernetes control plane -- notably the Shadow
+network simulator -- peers are not k8s pods: they are simulated hosts named by
+convention (``pod-0`` .. ``pod-(N-1)``) and reachable only through the
+simulator's internal DNS. This module resolves "static" ``ConfigTarget``s to
+``TargetPodInfo`` objects purely by expanding a hostname pattern, with no calls
+to the Kubernetes API.
+
+Keeping this in its own module is deliberate: the non-k8s resolution path never
+imports ``kube_client`` / the API client, so it works in a bare Python process
+inside the simulator. It mirrors what the legacy ``traffic_sync.py`` injector
+did (build ``pod-{i}`` names, let the OS resolver -- Shadow's DNS -- map them),
+but expressed through the requester's config model.
+"""
+
+from typing import List
+
+from configs import ConfigTarget
+from schemas import TargetPodInfo
+from utils import setup_logger
+
+logger = setup_logger(__file__)
+
+
+def expand_hosts(target: ConfigTarget) -> List[str]:
+    """Expand a static target into the concrete list of hostnames it addresses.
+
+    Two forms are supported:
+      * ``hosts``: an explicit list of hostnames.
+      * ``host_template`` + ``host_count``: ``host_template`` is formatted with
+        ``i`` over ``range(host_count)`` -- e.g. ``"pod-{i}"`` with
+        ``host_count=100`` yields ``pod-0`` .. ``pod-99``.
+    """
+    if target.hosts is not None:
+        return list(target.hosts)
+    if target.host_template is not None:
+        if target.host_count is None:
+            raise ValueError(
+                f"Static target `{target.name}` sets `host_template` but not `host_count`."
+            )
+        return [target.host_template.format(i=i) for i in range(target.host_count)]
+    raise ValueError(
+        f"Static target `{target.name}` must set either `hosts` or "
+        f"`host_template` (+ `host_count`)."
+    )
+
+
+def resolve_static_target(target: ConfigTarget) -> List[TargetPodInfo]:
+    """Resolve a static (non-k8s) target to ``TargetPodInfo`` objects by hostname.
+
+    The hostname is stored in ``TargetPodInfo.host``; it is substituted into the
+    endpoint URL's ``{node}`` and resolved by the HTTP client's OS resolver
+    (e.g. Shadow's internal DNS) at request time -- no IP lookup happens here.
+    """
+    hosts = expand_hosts(target)
+    preview = hosts[:5]
+    logger.info(
+        f"Resolved static target `{target.name}` to {len(hosts)} host(s): "
+        f"{preview}{' ...' if len(hosts) > 5 else ''}"
+    )
+    return [TargetPodInfo(config_target=target, host=host) for host in hosts]

--- a/utils.py
+++ b/utils.py
@@ -243,7 +243,9 @@ def paged_request(request: dict, max_attempts: PositiveInt, page_request_delay: 
         time.sleep(page_request_delay)
 
         logger.info(f"Making paged request. request: `{request}`, params=`{params}`")
-        response = requests.get(url, headers=request["headers"], params=params)
+        response = requests.get(
+            url, headers=request["headers"], params=params, timeout=request.get("timeout")
+        )
 
         try:
             data = response.json()


### PR DESCRIPTION
- **Static / DNS targets** — a `Target` can now be resolved by hostname. The hostname goe into the endpoint URL's `{node}` and is resolved by the OS resolver at request time. New `shadow_resolver.py` keeps this path isolated so it never imports the k8s client. Static and k8s targets can be mixed.
- **Import-safe k8s client** — `kube_client` used to call `load_incluster_config()` at module top, so *any* import of it (i.e. every entrypoint) tried to connect to Kubernetes. That crashes anywhere outside a pod — batch runs, Shadow, local dev, tests. It's now created lazily on first use (`get_core_v1()`), with an in-cluster→kubeconfig fallback so it also works against a cluster from outside a pod.
- **Batch-mode fixes** — `--mode batch` iterated the config dicts by key instead of value and passed a `ConfigRequest` where a `ConfigEndpoint` was expected. Fixed both, added a `--namespace` flag (optional when all targets are static), and made `ascending`/`descending` ordering numeric so `pod-2` sorts before `pod-10`.
- **Pacing & timeouts** — added `delay` on Actions to space out requests, and a `timeout` on Endpoints passed to the HTTP client, so one unresponsive target can't hang a whole batch run.
- **Lean batch** — `uvicorn`/`app` are imported lazily inside the server branch, so batch mode doesn't pull in the FastAPI/uvicorn deps it never uses.